### PR TITLE
AutoLog improvements and NoBreakDelay

### DIFF
--- a/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerAccessor.java
+++ b/src/main/java/meteordevelopment/meteorclient/mixin/ClientPlayerInteractionManagerAccessor.java
@@ -17,4 +17,7 @@ public interface ClientPlayerInteractionManagerAccessor {
 
     @Accessor("currentBreakingPos")
     BlockPos getCurrentBreakingBlockPos();
+
+    @Accessor("blockBreakingCooldown")
+    void setBlockBreakingCooldown(int cooldown);
 }

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoLog.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/misc/AutoLog.java
@@ -104,31 +104,44 @@ public class AutoLog extends Module {
             if(smartToggle.get()) {
                 this.toggle();
                 enableHealthListener();
+                return;
             }
         }
 
         if(smart.get() && playerHealth + mc.player.getAbsorptionAmount() - PlayerUtils.possibleHealthReductions() < health.get()){
             mc.player.networkHandler.onDisconnect(new DisconnectS2CPacket(Text.literal("[AutoLog] Health was going to be lower than " + health.get() + ".")));
-            if (toggleOff.get()) this.toggle();
+            if (toggleOff.get()) {
+                this.toggle();
+                return;
+            }
         }
 
         for (Entity entity : mc.world.getEntities()) {
             if (entity instanceof PlayerEntity && entity.getUuid() != mc.player.getUuid()) {
                 if (onlyTrusted.get() && entity != mc.player && !Friends.get().isFriend((PlayerEntity) entity)) {
                         mc.player.networkHandler.onDisconnect(new DisconnectS2CPacket(Text.literal("[AutoLog] A non-trusted player appeared in your render distance.")));
-                        if (toggleOff.get()) this.toggle();
+                        if (toggleOff.get()) {
+                            this.toggle();
+                            return;
+                        }
                         break;
                 }
                 if (PlayerUtils.isWithin(entity, 8) && instantDeath.get() && DamageUtils.getSwordDamage((PlayerEntity) entity, true)
                         > playerHealth + mc.player.getAbsorptionAmount()) {
                     mc.player.networkHandler.onDisconnect(new DisconnectS2CPacket(Text.literal("[AutoLog] Anti-32k measures.")));
-                    if (toggleOff.get()) this.toggle();
+                    if (toggleOff.get()) {
+                        this.toggle();
+                        return;
+                    }
                     break;
                 }
             }
             if (entity instanceof EndCrystalEntity && PlayerUtils.isWithin(entity, range.get()) && crystalLog.get()) {
                 mc.player.networkHandler.onDisconnect(new DisconnectS2CPacket(Text.literal("[AutoLog] End Crystal appeared within specified range.")));
-                if (toggleOff.get()) this.toggle();
+                if (toggleOff.get()) {
+                    this.toggle();
+                    return;
+                }
             }
         }
     }
@@ -139,7 +152,8 @@ public class AutoLog extends Module {
             if (isActive()) disableHealthListener();
 
             else if (Utils.canUpdate()
-                    && !mc.player.isDead()
+                    && mc.player != null
+                    && mc.player.canTakeDamage()
                     && mc.player.getHealth() > health.get()) {
                 toggle();
                 disableHealthListener();

--- a/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoBreakDelay.java
+++ b/src/main/java/meteordevelopment/meteorclient/systems/modules/player/NoBreakDelay.java
@@ -5,11 +5,19 @@
 
 package meteordevelopment.meteorclient.systems.modules.player;
 
+import meteordevelopment.meteorclient.events.entity.player.PlayerMoveEvent;
+import meteordevelopment.meteorclient.mixin.ClientPlayerInteractionManagerAccessor;
 import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
+import meteordevelopment.orbit.EventHandler;
 
 public class NoBreakDelay extends Module {
     public NoBreakDelay() {
         super(Categories.Player, "no-break-delay", "Completely removes the delay between breaking blocks.");
+    }
+
+    @EventHandler
+    private void onPlayerMove(PlayerMoveEvent event) {
+        ((ClientPlayerInteractionManagerAccessor) mc.interactionManager).setBlockBreakingCooldown(0);
     }
 }


### PR DESCRIPTION
NoBreakDelay wasn't implemented so now it is.

AutoLog smartToggle now checks if player `canTakeDamage` instead of `isDead` because before it would pass while player was loading into a multiplayer game and end up thinking the player is full health and re-able the module. Then the player loads in and the health is still low and the cycle continues.